### PR TITLE
fix:  USB CDC/MDC on Cygnet

### DIFF
--- a/ports/stm/boards/STM32L433_boot.ld
+++ b/ports/stm/boards/STM32L433_boot.ld
@@ -7,7 +7,7 @@ MEMORY
 {
     FLASH (rx)          : ORIGIN = 0x08000000, LENGTH = 256k /* entire flash */
     FLASH_ISR (rx)      : ORIGIN = 0x08010000, LENGTH = 4K /* ISR vector. Kind of wasteful. */
-    FLASH_FIRMWARE (rx) : ORIGIN = 0x08011000, LENGTH = 192K-64K-4K  /* For now, limit to 1MB so that bank switching is still possible. */
+    FLASH_FIRMWARE (rx) : ORIGIN = 0x08011000, LENGTH = 192K-64K-4K
     FLASH_FS (rw)       : ORIGIN = 0x08030000, LENGTH = 60K
     RAM (xrw)           : ORIGIN = 0x20000000, LENGTH = 640K
 }

--- a/ports/stm/common-hal/microcontroller/__init__.c
+++ b/ports/stm/common-hal/microcontroller/__init__.c
@@ -31,12 +31,14 @@ void common_hal_mcu_delay_us(uint32_t delay) {
     SysTick->CTRL = 0UL;
 }
 
-volatile uint32_t nesting_count = 0;
+static volatile uint32_t nesting_count = 0;
 
+// 32-bit increments 
 void common_hal_mcu_disable_interrupts(void) {
-    __disable_irq();
-    __DMB();
-    nesting_count++;
+    if (++nesting_count==1) {
+        __disable_irq();
+        __DMB();
+    }
 }
 
 void common_hal_mcu_enable_interrupts(void) {
@@ -44,12 +46,10 @@ void common_hal_mcu_enable_interrupts(void) {
         // This is very very bad because it means there was mismatched disable/enables.
         reset_into_safe_mode(SAFE_MODE_INTERRUPT_ERROR);
     }
-    nesting_count--;
-    if (nesting_count > 0) {
-        return;
+    if (--nesting_count == 0) {
+        __DMB();
+        __enable_irq();
     }
-    __DMB();
-    __enable_irq();
 }
 
 static bool next_reset_to_bootloader = false;

--- a/ports/stm/peripherals/periph.h
+++ b/ports/stm/peripherals/periph.h
@@ -137,3 +137,7 @@ typedef struct {
 #define HAS_BASIC_TIM 0
 #include "stm32h7/stm32h743xx/periph.h"
 #endif
+
+#if !defined(HAS_DAC)
+#error Unknown MCU
+#endif

--- a/ports/stm/peripherals/stm32l4/clocks.c
+++ b/ports/stm/peripherals/stm32l4/clocks.c
@@ -9,9 +9,9 @@
 #include <stdbool.h>
 
 // L4 Series
-#ifdef STM32L4R5xx
+#if defined(STM32L4R5xx)
 #include "stm32l4/stm32l4r5xx/clocks.h"
-#elif STM32L433xx
+#elif defined(STM32L433xx)
 #include "stm32l4/stm32l433xx/clocks.h"
 #else
 #error Please add other MCUs here so that they are not silently ignored due to #define typos
@@ -46,18 +46,18 @@ void stm32_peripherals_clocks_init(void) {
 
     /** Configure the main internal regulator output voltage
   */
-    #if STM32L4R5xx
+    #if defined(STM32L4R5xx)
     if (HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1_BOOST) != HAL_OK) {
         Error_Handler();
     }
-    #elif STM32L433xx
+    #elif defined(STM32L433xx)
     if (HAL_PWREx_ControlVoltageScaling(PWR_REGULATOR_VOLTAGE_SCALE1) != HAL_OK) {
         Error_Handler();
     }
     #endif
 
     /* Activate PLL with MSI , stabilizied via PLL by LSE */
-    #ifdef STM32L4R5xx
+    #if defined(STM32L4R5xx)
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_MSI;
     RCC_OscInitStruct.MSIState = RCC_MSI_ON;
     RCC_OscInitStruct.LSEState = RCC_LSE_ON;
@@ -70,7 +70,7 @@ void stm32_peripherals_clocks_init(void) {
     RCC_OscInitStruct.PLL.PLLN = 30;
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV5;
     RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
-    #elif STM32L433xx
+    #elif defined(STM32L433xx)
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE | RCC_OSCILLATORTYPE_HSI48 | RCC_OSCILLATORTYPE_MSI;
     RCC_OscInitStruct.HSI48State = RCC_HSI48_ON;
     RCC_OscInitStruct.MSIState = RCC_MSI_ON;
@@ -84,6 +84,8 @@ void stm32_peripherals_clocks_init(void) {
     RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV7;
     RCC_OscInitStruct.PLL.PLLQ = RCC_PLLQ_DIV2;
     RCC_OscInitStruct.PLL.PLLR = RCC_PLLR_DIV2;
+    #else
+    #error Unknown MCU
     #endif
 
     HAL_CHECK(HAL_RCC_OscConfig(&RCC_OscInitStruct));
@@ -100,10 +102,12 @@ void stm32_peripherals_clocks_init(void) {
     RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
-    #ifdef STM32L4R5xx
+    #if defined(STM32L4R5xx)
     HAL_CHECK(HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_3));
-    #elif STM32L433xx
+    #elif defined(STM32L433xx)
     HAL_CHECK(HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_4));
+    #else
+      #error Please expand the conditional compilation to set the default flash latency
     #endif
 
     /* AHB prescaler divider at 1 as second step */
@@ -115,9 +119,9 @@ void stm32_peripherals_clocks_init(void) {
 
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB | RCC_PERIPHCLK_RTC | RCC_PERIPHCLK_ADC;
-    #ifdef STM32L4R5xx
+    #if defined(STM32L4R5xx)
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI;
-    #elif STM32L433xx
+    #elif defined(STM32L433xx)
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_HSI48;
     #endif
     PeriphClkInitStruct.RTCClockSelection = RCC_RTCCLKSOURCE_LSE;

--- a/ports/stm/supervisor/internal_flash.c
+++ b/ports/stm/supervisor/internal_flash.c
@@ -69,13 +69,13 @@ static const flash_layout_t flash_layout[] = {
 };
 static uint8_t _flash_cache[0x20000] __attribute__((aligned(4)));
 
-#elif defined(STM32L4R5XX)
+#elif defined(STM32L4R5xx)
 static const flash_layout_t flash_layout[] = {
     { 0x08100000, 0x1000, 256 },
 };
 static uint8_t _flash_cache[0x1000] __attribute__((aligned(4)));
 
-#elif defined(STM32L433XX)
+#elif defined(STM32L433xx)
 static const flash_layout_t flash_layout[] = {
     { 0x08000000, 0x0800, 128 },
 };
@@ -181,10 +181,10 @@ void port_internal_flash_flush(void) {
     // set up for erase
     FLASH_EraseInitTypeDef EraseInitStruct = {};
     #if CPY_STM32L4
-    #if defined(STM32L4R5XX)
+    #if defined(STM32L4R5xx)
     EraseInitStruct.TypeErase = TYPEERASE_PAGES;
     EraseInitStruct.Banks = FLASH_BANK_2;           // filesystem stored in upper 1MB of flash in dual bank mode
-    #elif defined(STM32L433XX)
+    #elif defined(STM32L433xx)
     EraseInitStruct.TypeErase = TYPEERASE_PAGES;
     EraseInitStruct.Banks = FLASH_BANK_1;
     #endif


### PR DESCRIPTION
Fixes USB on Cygnet.

Major changes, enabling USB functionality:

* The L433 doesn't support USB OTG, hence the USB ISR has a different name with the L433 compared to the L4R5.
* The enable/disable interrupts code was failing and disabling all interrupts after a certain period because it was using non-atomic operations. I rewrote the code to use atomic operations so that interrupts are re-enabled correctly. (Edit: I'm not convinced the new code is actually atomic, but could have resulted in a compiler optimization error.)

Minor changes:

* Normalized the defines that differ by case (`STM32L4R5xx` / `STM32L4R5XX`) to use only the lowercase version, and similarly for the L433, which were only causing confusion.
* Tidied up some defines that were using preprocessor symbols in a way that implied they were guaranteed to be defined, being either 0 or 1, but in reality are only defined when targeting certain boards.
* indented `init_usb_vbus_sense()` to make the nested conditionals clearer to read.
